### PR TITLE
[RFC] Allow prefilling of scripts and stylesheets

### DIFF
--- a/src/Resources/contao/classes/BackendTemplate.php
+++ b/src/Resources/contao/classes/BackendTemplate.php
@@ -73,7 +73,7 @@ class BackendTemplate extends \Template
 				$strStyleSheets .= \Template::generateStyleTag($this->addStaticUrlTo($stylesheet), $options->media);
 			}
 
-			$this->stylesheets = $strStyleSheets;
+			$this->stylesheets .= $strStyleSheets;
 		}
 
 		// JavaScripts
@@ -87,7 +87,7 @@ class BackendTemplate extends \Template
 				$strJavaScripts .= \Template::generateScriptTag($this->addStaticUrlTo($javascript), $options->async) . "\n";
 			}
 
-			$this->javascripts = $strJavaScripts;
+			$this->javascripts .= $strJavaScripts;
 		}
 
 		// MooTools scripts (added at the page bottom)
@@ -100,7 +100,7 @@ class BackendTemplate extends \Template
 				$strMootools .= "\n" . trim($script) . "\n";
 			}
 
-			$this->mootools = $strMootools;
+			$this->mootools .= $strMootools;
 		}
 
 		$strBuffer = $this->parse();


### PR DESCRIPTION
IMO the backend template should only append variables and not kill values set by the developer in the parse method but rather append to them.

This way one may define custom stylesheets and scripts from within an custom backend controller that will not get overridden by the template.

I am using this in a custom backend controller template based upon `be_main.html.twig`:
```twig
{{ render_contao_backend_template({
    main: block('main'),
    error: block('error'),
    headline: block('headline'),
    stylesheets: block('stylesheets'),
    javascripts: block('javascripts'),
    mootools: block('mootools')
}) | raw }}

{# 
  Here we generate the stylesheets to be added to be_main instead of adding 
  stuff to $GLOBALS['TL_CSS'] within a Symfony controller.
#}
{% block stylesheets %}
    {% for stylesheet in stylesheets %}
        <link rel="stylesheet" href="{{ stylesheet }}">
    {% endfor %}
{% endblock %}
{# 
  Here we generate the javascripts to be added to be_main instead of adding 
  stuff to $GLOBALS['TL_JAVASCRIPT'] within a Symfony controller.
  TODO: add support for "async" here.
#}
{% block javascripts %}
    {% for javascript in javascripts %}
        <script src="{{ javascript }}"></script>
    {% endfor %}
{% endblock %}
{# 
  Here we have the mootools scripts to be added to be_main instead of adding 
  stuff to $GLOBALS['TL_MOOTOOLS'] within a Symfony controller.
#}
{% block mootools %}
    {% for mootool in mootools %}
        {{ mootool }}
    {% endfor %}
{% endblock %}
....
```

So we have now:
- three added dots in this PR
- a custom twig template

And I am able to do anything in a custom controller without any reference to `$GLOBALS`

@contao/developers what do you think? Shall we also expand the shipped template then?
